### PR TITLE
Added an additional tag/token 'lastelement' that contains the last el…

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
       "nl": "MQTT Client"
    },
    "description": {
-      "en": "Subscripe to MQTT topics",
+      "en": "Subscribe to MQTT topics",
       "nl": "Abonneer op MQTT topics"
    },
    "version": "2.0.3",
@@ -57,6 +57,14 @@
                      "nl": "Naam Topic"
                   },
                   "example": "broker/+/something/#"
+               },
+               {
+                  "name": "lastelement",
+                  "title": {
+                     "en": "Last element of Topic",
+                     "nl": "Laatste element van Topic"
+                  },
+                  "example": "Contains the last element of the topic address"
                }
             ],
             "args":[
@@ -150,14 +158,6 @@
                        }
                     }
                  ]
-              },
-              {
-                 "name": "retain",
-                 "type": "checkbox",
-                 "title": {
-                    "en": "retain",
-                    "nl": "retain"
-                 }
               }
             ]
          },

--- a/messagehandling.js
+++ b/messagehandling.js
@@ -16,24 +16,28 @@ class handlingMQTT {
       this.logmodule = app.logmodule;
       this.triggers  = app.triggers;
    }
-   
+
    receiveMessage(topic, message, args, state) {
       var validJSON = true;
-      this.logmodule.writelog('info', "received '" + message.toString() + "' on '" + topic + "'");
+      var topicelements = topic.split('/');
+      var lastelement = topicelements.pop();
+
+      this.logmodule.writelog('info', "received '" + message.toString() + "' on '" + topic + "', and last element of topic is: '" + lastelement + "'");
 
       let tokens = {
          message: message.toString(),
-         topic: topic
+         topic: topic,
+         lastelement: lastelement
       }
-   
+
       let triggerstate = {
-         triggerTopic: topic, 
+         triggerTopic: topic,
       }
-   
+
       this.triggers.getEventMQTT().trigger(tokens, triggerstate, null);
       this.logmodule.writelog('info', "Trigger generic card for " + topic);
    }
-   
+
    updateRef(app) {
       this.triggers = app.triggers;
    }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "og",
+  "name": "nl.scanno.mqtt",
   "version": "2.0.3",
   "description": "MQTT Client PVS",
   "main": "app.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nl.scanno.mqtt",
   "version": "2.0.3",
-  "description": "MQTT Client PVS",
+  "description": "MQTT Client",
   "main": "app.js",
   "dependencies": {
     "mqtt": "^1.7.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "nl.scanno.mqtt",
+  "name": "og",
   "version": "2.0.3",
-  "description": "MQTT Client",
+  "description": "MQTT Client PVS",
   "main": "app.js",
   "dependencies": {
     "mqtt": "^1.7.2"

--- a/triggers.js
+++ b/triggers.js
@@ -1,4 +1,4 @@
-"use strict";	
+"use strict";
 //const globalVarMQTT = require("./global.js");
 
 class triggerMQTT {
@@ -34,7 +34,7 @@ class triggerMQTT {
             } else {
                return Promise.resolve( false );
             }
-          } catch(err) {	
+          } catch(err) {
             this.logmodule.writelog('error', "Error in Listener eventMQTT: " +err);
             return Promise.reject(err);
           }
@@ -125,7 +125,7 @@ class triggerMQTT {
    setArgumentChangeEvent() {
       const ref = this;
       // We need to know when an argument in a trigger has changed, has been added or removed.
-      // If so, we need to change, remove or add topic subscriptions. So register to the 
+      // If so, we need to change, remove or add topic subscriptions. So register to the
       // trigger update event.
       this.eventMQTT.on('update', () => {
          this.logmodule.writelog('info', "Trigger changed" );
@@ -134,7 +134,7 @@ class triggerMQTT {
          this.eventMQTT.getArgumentValues(function( err, values ) {
             ref.logmodule.writelog('info', "topics:" + ref.globalVar.getTopicArray());
 
-            // Check if there are already subscribed topics. If so, then unsubsribe because we 
+            // Check if there are already subscribed topics. If so, then unsubsribe because we
             // need to loop through all triggers and just unsubscribe and re-subscribe again is faster.
             if (ref.globalVar.getTopicArray().length > 0) {
                ref.broker.getConnectedClient().unsubscribe(ref.globalVar.getTopicArray());
@@ -150,11 +150,10 @@ class triggerMQTT {
 
       });
    }
-   
+
    getEventMQTT() {
       return this.eventMQTT;
    }
 }
 
 module.exports = triggerMQTT;
-


### PR DESCRIPTION
Added an addtional tag ("lastelement"), that contains the last element of the Topic that has triggered. This allows for OpenHAB style MQTT protocol communication, whereby 'lastelement' contains the measurement-name and 'message' the value of that variable.

I use it for reading from ESP_Easy connected sensors, and passing the values on to a virtual device.

Example:
- ESPEasy device with a BME280 sensor, that measures temperature, humidity, and pressure;
- ESPEasy publishes these measurements in the following Topics: /ESP_Easy/BME280/Temp; /ESP_Easy/BME280/Humidity; /ESP_EASY/BME280/Pressure;
- I have created a Flow with as a Trigger a MQTT-client card that listens to "/ESP_Easy/BME280/+". Note the wildcard;
- When trigerred, for each published measurement a token "lastelement" is passed to a virtual devices as the sensorname, and token "message" as the value of that sensor;
- The number of sensors / measurements defined in ESP Easy dictates the number of subtopics, and therefore the number of times this flow is triggered.
- measurements are now tracked in Insights;
- measurement values of the virtual device can be used to trigger other flows.

Note:
to get the app to compile I had to delete the "retain checkbox" from app.json. May want to put that back.
,
              {
                 "name": "retain",
                 "type": "checkbox",
                 "title": {
                    "en": "retain",
                    "nl": "retain"
                 }
              }