### PR TITLE
Stringify object types only to allow sending 0 and false values.

### DIFF
--- a/broker.js
+++ b/broker.js
@@ -281,7 +281,7 @@ class brokerMQTT {
 
             } else {
                 // parse objects to string
-                if (args.mqttMessage && typeof args.mqttMessage === 'object' && typeof args.mqttMessage !== null) {
+                if (args.mqttMessage !== undefined && typeof args.mqttMessage !== 'string' && typeof args.mqttMessage !== null) {
                     args.mqttMessage = JSON.stringify(args.mqttMessage);
                 }
 

--- a/broker.js
+++ b/broker.js
@@ -281,7 +281,7 @@ class brokerMQTT {
 
             } else {
                 // parse objects to string
-                if (args.mqttMessage && typeof args.mqttMessage !== 'string' && typeof args.mqttMessage !== null) {
+                if (args.mqttMessage && typeof args.mqttMessage === 'object' && typeof args.mqttMessage !== null) {
                     args.mqttMessage = JSON.stringify(args.mqttMessage);
                 }
 


### PR DESCRIPTION

Stringify object types only to allow sending 0 and false values.
This way the orignal value type isn't changed to string and e.g. boolean and numbers are forwarded correctly.

Fix for: https://github.com/harriedegroot/nl.hdg.mqtt/issues/21